### PR TITLE
update(deps): update node-exist and remove mime

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,11 +3,10 @@ var os = require('os')
 var through = require('through2')
 var log = require('fancy-log')
 var PluginError = require('plugin-error')
-var mime = require('mime')
 var assign = require('lodash.assign')
 var File = require('vinyl')
 var Path = require('path')
-var exist = require('node-exist')
+var exist = require('@existdb/node-exist')
 
 var defaultRPCoptions = {
   host: 'localhost',
@@ -57,11 +56,11 @@ module.exports.createClient = function createClient (options) {
 }
 
 module.exports.defineMimeTypes = function (mimeTypes) {
-  mime.define(mimeTypes)
+  exist.defineMimeTypes(mimeTypes)
 }
 
-module.exports.getMimeTypes = function () {
-  return mime.types
+module.exports.getMimeType = function (path) {
+  return exist.getMimeType(path)
 }
 
 function sendFilesWith (client) {
@@ -104,13 +103,13 @@ function sendFilesWith (client) {
 
         // then upload file
         .then(function (result) {
-          log('Storing "' + file.base + file.relative + '" as (' + mime.lookup(file.path) + ')...')
+          log('Storing "' + file.base + file.relative + '" as (' + exist.getMimeType(file.path) + ')...')
           return client.documents.upload(file.contents)
         })
 
         // parse file on server
         .then(function (result) {
-          return client.documents.parseLocal(result, remotePath, {mimetype: mime.lookup(file.path)})
+          return client.documents.parseLocal(result, remotePath, {mimetype: exist.getMimeType(file.path)})
         })
 
         // handle re-upload as octet stream if parsing failed and html5AsBinary is set

--- a/package-lock.json
+++ b/package-lock.json
@@ -3,6 +3,23 @@
   "requires": true,
   "lockfileVersion": 1,
   "dependencies": {
+    "@existdb/node-exist": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@existdb/node-exist/-/node-exist-1.0.4.tgz",
+      "integrity": "sha512-k1wyZ2LD8KJLvadX5hGJaVPj1FJuXk3bdmptJzKFL5QQLPKT0XPmpg9zN5jIZrCTr9lGm1ooJ2bZUs6OEVQBZQ==",
+      "requires": {
+        "lodash.assign": "^4.0.2",
+        "mime": "^2.3.1",
+        "xmlrpc": "^1.3.1"
+      },
+      "dependencies": {
+        "mime": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-2.3.1.tgz",
+          "integrity": "sha512-OEUllcVoydBHGN1z84yfQDimn58pZNNNXgZlHXSboxMlFvgI6MXSWpWKpFRra7H1HxpVhHTkrghfRW49k6yjeg=="
+        }
+      }
+    },
     "@mrmlnc/readdir-enhanced": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz",
@@ -4623,11 +4640,6 @@
         "to-regex": "^3.0.2"
       }
     },
-    "mime": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
-      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="
-    },
     "mimic-fn": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
@@ -4807,16 +4819,6 @@
       "dev": true,
       "requires": {
         "lodash.toarray": "^4.4.0"
-      }
-    },
-    "node-exist": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/node-exist/-/node-exist-0.3.0.tgz",
-      "integrity": "sha1-WkD7AKAcoKhuHFMSkB83NNI13/w=",
-      "requires": {
-        "lodash.assign": "^4.0.2",
-        "mime": "^1.3.4",
-        "xmlrpc": "^1.3.1"
       }
     },
     "node-fetch": {

--- a/package.json
+++ b/package.json
@@ -35,8 +35,7 @@
     "fancy-log": "^1.3.2",
     "gulp": "^4.0.0",
     "lodash.assign": "^4.2.0",
-    "mime": "^1.3.4",
-    "node-exist": "^0.3.0",
+    "@existdb/node-exist": "^1.0.4",
     "plugin-error": "^1.0.1",
     "through2": "^2.0.3",
     "vinyl": "^1.1.1"

--- a/spec/test.js
+++ b/spec/test.js
@@ -3,7 +3,7 @@
 var gulp = require('gulp')
 var test = require('tape')
 var gulpExist = require('../index')
-var exist = require('node-exist')
+var exist = require('@existdb/node-exist')
 
 var srcOptions = { cwd: 'spec/files' }
 
@@ -17,18 +17,17 @@ var connectionOptions = {
 }
 
 test('check for default mime type extensions', function (t) {
-  var types = gulpExist.getMimeTypes()
-  t.equals(types['xq'], 'application/xquery')
-  t.equals(types['xql'], 'application/xquery')
-  t.equals(types['xqm'], 'application/xquery')
-  t.equals(types['xconf'], 'application/xml')
-  t.equals(types['odd'], 'application/xml')
+  t.equals(gulpExist.getMimeType('test.xq'), 'application/xquery')
+  t.equals(gulpExist.getMimeType('test.xql'), 'application/xquery')
+  t.equals(gulpExist.getMimeType('test.xqm'), 'application/xquery')
+  t.equals(gulpExist.getMimeType('test.xconf'), 'application/xml')
+  t.equals(gulpExist.getMimeType('test.odd'), 'application/xml')
   t.end()
 })
 
 test('extend mime type definitions', function (t) {
   gulpExist.defineMimeTypes({ 'text/foo': ['bar'] })
-  t.equals(gulpExist.getMimeTypes()['bar'], 'text/foo')
+  t.equals(gulpExist.getMimeType('test.bar'), 'text/foo')
   t.end()
 })
 


### PR DESCRIPTION
BREAKING CHANGE: `getMimeTypes()` was replaced by `getMimeType(path)`
This was necessary, because the property `mime.types`, is now private.
Also, there is not really a need to get
the complete list of all defined mime-types.

gulp-exist now depends on the latest, scoped version of node-exist.

Since node-exist already exposes all the necessary functionality of mime
and having to instances of it is also error-prone, it was removed.