### PR TITLE
fix (ci): remove node_modules from caching

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,5 +50,4 @@ before_cache:
 
 cache:
   directories:
-    - node_modules
     - ${HOME}/exist


### PR DESCRIPTION
Builds will fail otherwise with node v6. This is a known issue in travis and does not affect build time too much.