### PR TITLE
Ease package installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,9 +189,12 @@ exports.default = deployWithPermissions
 
 #### Options
 
-##### packageUri
+##### packageUri (deprecated)
 
 The unique package descriptor of the application to be installed.
+
+**NOTE:** For versions after v4.0.2 this option is ignored and will be read 
+from the XAR itself.
 
 ##### customPackageRepoUrl
 
@@ -211,12 +214,10 @@ const exist = createClient({
         pass: ''
     }
 })
-// this MUST be the unique package identifier of the XAR you want to install 
-const packageUri = 'http://exist-db.org/apps/test-app'
 
 function install () {
     return src('spec/files/test-app.xar')
-        .pipe(exist.install({ packageUri }))
+        .pipe(exist.install())
 }
 ```
 

--- a/index.js
+++ b/index.js
@@ -281,7 +281,7 @@ function newer (client, options) {
 
 /**
  * @typedef {Object} GulpExistInstallationOptions
- * @prop {string} packageUri
+ * @prop {string} [packageUri] deprecated
  * @prop {string} [customPackageRepoUrl]
  */
 
@@ -293,9 +293,7 @@ function newer (client, options) {
  * @return {TransformFunction} install XAR from vinyl file stream
  */
 function install (client, options) {
-  if (!options || !options.packageUri) { return new PluginError('gulp-exist', 'packageUri must be declared') }
-  const packageUri = options.packageUri
-  const customPackageRepoUrl = options.customPackageRepoUrl || null
+  const customPackageRepoUrl = options && options.customPackageRepoUrl ? options.customPackageRepoUrl : null
 
   function installPackage (file, enc, callback) {
     const xarName = file.basename
@@ -310,8 +308,8 @@ function install (client, options) {
     client.app.upload(file.contents, xarName)
       .then(response => {
         if (!response.success) { return callback(new PluginError('gulp-exist', 'XAR was not uploaded')) }
-        log(`Install ${packageUri} from ${xarName}`)
-        return client.app.install(xarName, packageUri, customPackageRepoUrl)
+        log(`Install ${xarName}`)
+        return client.app.install(xarName, customPackageRepoUrl)
       })
       .then(response => {
         if (!response.success) { return callback(new PluginError('gulp-exist', 'XAR Installation failed')) }

--- a/package-lock.json
+++ b/package-lock.json
@@ -103,9 +103,9 @@
       }
     },
     "@existdb/node-exist": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@existdb/node-exist/-/node-exist-3.0.1.tgz",
-      "integrity": "sha512-otZiT+SfpZBWJUOrKo9ETr47AcKebJZxDmFFdMHCaC/TfpuqD6HmvllZwsEx7xW++MCt/6MHcqALblimMlID0A==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@existdb/node-exist/-/node-exist-4.0.0.tgz",
+      "integrity": "sha512-lszEmIXBW09bpXZzSWzXppMezExDjWgD7WvyVl3KABp9lEreBR43OoZjNVs4XYszan1CnrUQkkK1Sdo7UkaVzg==",
       "requires": {
         "lodash.assign": "^4.0.2",
         "mime": "^2.3.1",

--- a/package.json
+++ b/package.json
@@ -47,10 +47,10 @@
     "tape": "^5.0.1"
   },
   "dependencies": {
+    "@existdb/node-exist": "^4.0.0",
     "fancy-log": "^1.3.2",
     "gulp": "^4.0.2",
     "lodash.assign": "^4.2.0",
-    "@existdb/node-exist": "^3.0.1",
     "plugin-error": "^1.0.1",
     "through2": "^4.0.2",
     "vinyl": "^2.2.1"

--- a/spec/install.js
+++ b/spec/install.js
@@ -19,7 +19,7 @@ test('install XAR package', function (t) {
   }
 
   return gulp.src('test-app.xar', { cwd: 'spec/files' })
-    .pipe(testClient.install({ packageUri }))
+    .pipe(testClient.install())
     .on('data', function (d) {
       t.plan(3)
       t.true(d.success, 'succeeded')


### PR DESCRIPTION
- gulp-exist$install does not require and will ignore the
  `packageUri` option.
  This metadata is now read from the XAR that is uploaded.
- update to node-exist@4