### PR TITLE
feat: allow to pass parameters when executing query

### DIFF
--- a/README.md
+++ b/README.md
@@ -427,6 +427,9 @@ Pass a variable to the XQuery script.
 *scripts/var.xq*
 
 ```xquery
+(: optionally declare the variable as external :)
+declare variable $someVariable external;
+
 <result>{ $someVariable }</result>
 ```
 

--- a/README.md
+++ b/README.md
@@ -453,7 +453,7 @@ const queryConfig = {
 	}
 }
 
-function runQueryWithVarible () {
+function runQueryWithVariable () {
 	return src('scripts/var.xq', {cwd: '.'})
 		.pipe(exist.query(queryConfig))
         .pipe(dest('logs'))

--- a/README.md
+++ b/README.md
@@ -363,7 +363,16 @@ The filename extension that will be used for XQuery result files emitted by
 Type: `string`
 Default: `'xml'`
 
-#### Example
+##### queryParams
+
+Query params passed to the eXist-db XMLRPC API
+(https://exist-db.org/exist/apps/doc/devguide_xmlrpc). Can be used to pass
+query variables (see Example 2).
+
+Type: `Object`
+Default: `{}`
+
+#### Example 1
 
 Upload a collection index configuration file and re-index the collection
 
@@ -409,6 +418,48 @@ function reindex () {
 }
 
 exports.default = series(deployCollectionXConf, reindex)
+```
+
+#### Example 2
+
+Pass a variable to the XQuery script.
+
+*scripts/var.xq*
+
+```xquery
+<result>{ $someVariable }</result>
+```
+
+*gulpfile.js*
+
+```js
+const { src, dest } = require('gulp')
+const { createClient } = require('@existdb/gulp-exist')
+
+// override some default connection options
+const exist = createClient({
+    basic_auth: {
+        user: "admin",
+        pass: ""
+    }
+})
+
+// set `variables` query parameter
+const queryConfig = {
+	queryParams: {
+	    variables: {
+	        someVariable: "some value"
+	    }
+	}
+}
+
+function runQueryWithVarible () {
+	return src('scripts/var.xq', {cwd: '.'})
+		.pipe(exist.query(queryConfig))
+        .pipe(dest('logs'))
+}
+
+exports.default = runQueryWithVarible
 ```
 
 ## Define Custom Mime Types

--- a/index.js
+++ b/index.js
@@ -70,6 +70,7 @@ const defaultUploadOptions = {
  * @typedef {Object} GulpExistQueryOptions
  * @prop {boolean} [printXqlResults] default: true
  * @prop {"xml"|"json"|string} xqlOutputExt the file extension the results are written to
+ * @prop {Object} queryParams query parameters passed to eXist-db
  */
 
 /**
@@ -77,7 +78,8 @@ const defaultUploadOptions = {
  */
 const defaultQueryOptions = {
   printXqlResults: true,
-  xqlOutputExt: 'xml'
+  xqlOutputExt: 'xml',
+  queryParams: {}
 }
 
 const isWin = os.platform() === 'win32'
@@ -223,7 +225,7 @@ function query (client, options) {
 
     log('Running XQuery on server: ' + file.relative)
 
-    client.queries.readAll(file.contents, {})
+    client.queries.readAll(file.contents, conf.queryParams)
       .then(function (result) {
         const resultBuffer = Buffer.concat(result.pages)
         if (conf.printXqlResults) {

--- a/spec/files/test-variables.xql
+++ b/spec/files/test-variables.xql
@@ -1,0 +1,6 @@
+xquery version "3.0";
+
+declare option exist:serialize "method=json media-type=text/javascript";
+
+(: return value of $variable that should have been set in the query parameters:)
+<result>{$variable}</result>

--- a/spec/files/test-variables.xql
+++ b/spec/files/test-variables.xql
@@ -5,4 +5,4 @@ declare option exist:serialize "method=json media-type=text/javascript";
 declare variable $variable external;
 
 (: return value of $variable that should have been set in the query parameters:)
-<result>{$variable}</result>
+$variable

--- a/spec/files/test-variables.xql
+++ b/spec/files/test-variables.xql
@@ -2,5 +2,7 @@ xquery version "3.0";
 
 declare option exist:serialize "method=json media-type=text/javascript";
 
+declare variable $variable external;
+
 (: return value of $variable that should have been set in the query parameters:)
 <result>{$variable}</result>

--- a/spec/query.js
+++ b/spec/query.js
@@ -47,3 +47,25 @@ test('run query, expect json', function (t) {
     .on('error', e => t.fail(e))
     .on('finish', _ => t.end())
 })
+
+test('run query with variables', function (t) {
+  const testClient = createClient(connectionOptions)
+  return src('test-variables.xql', srcOptions)
+    .pipe(testClient.query({
+      target: targetCollection,
+      xqlOutputExt: 'json',
+      queryParams: {
+        variables: {
+          variable: 'test'
+        }
+      }
+    }))
+    .on('data', function (d) {
+      const parsedContents = JSON.parse(d.contents)
+      // inspect the results
+      // result should be the string set by the variables object in the query params
+      t.equal(parsedContents, 'test', 'variable has been set')
+    })
+    .on('error', e => t.fail(e))
+    .on('finish', _ => t.end())
+})

--- a/spec/query.js
+++ b/spec/query.js
@@ -53,7 +53,6 @@ test('run query with variables', function (t) {
   return src('test-variables.xql', srcOptions)
     .pipe(testClient.query({
       target: targetCollection,
-      xqlOutputExt: 'json',
       queryParams: {
         variables: {
           variable: 'test'
@@ -61,10 +60,11 @@ test('run query with variables', function (t) {
       }
     }))
     .on('data', function (d) {
-      const parsedContents = JSON.parse(d.contents)
+      const contents = d.contents.toString()
+
       // inspect the results
       // result should be the string set by the variables object in the query params
-      t.equal(parsedContents, 'test', 'variable has been set')
+      t.equal(contents, 'test', 'variable has been set')
     })
     .on('error', e => t.fail(e))
     .on('finish', _ => t.end())


### PR DESCRIPTION
This PR allows parameters to be set in `gulp-exist#query` which will then be passed to the query.
Essentially, we will get something like SQL prepared statements.
